### PR TITLE
Upgrade PostgreSQL and get rid of json import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 sudo: false
 language: python
 addons:
-  postgresql: 9.6
+  postgresql: 10.4
+  apt:
+    packages:
+    - postgresql-10
+    - postgresql-client-10
+    - postgresql-server-dev-10
+    - postgresql-contrib
 python:
   - 3.6
 env:
@@ -14,6 +20,6 @@ install:
 script:
   - flake8 .
   - isort --check-only --diff --quiet
-  - pytest
+  - pytest -rs -v
 notifications:
   email: false

--- a/ursh/testing/conftest.py
+++ b/ursh/testing/conftest.py
@@ -12,7 +12,7 @@ from ursh.core.db import db as db_
 
 
 POSTGRES_MIN_VERSION = (9, 2)
-POSTGRES_VERSION = (10, )
+POSTGRES_VERSION = (9, 6)
 POSTGRES_PREFIX = '/usr/lib/postgresql/{version}/bin'.format(version='.'.join(map(str, POSTGRES_VERSION)))
 
 

--- a/ursh/testing/test_resources.py
+++ b/ursh/testing/test_resources.py
@@ -3,7 +3,11 @@ from uuid import uuid4
 
 import pytest
 
+import ursh
 from ursh.models import URL, Token
+
+
+ursh.models.ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-'
 
 
 @pytest.fixture


### PR DESCRIPTION
Ubuntu 18.04 uses version 10 (more precisely 10.4) as the default and the 9.6 path is no longer valid for version 10.

Seems to be OK with travis and works fine for local runs as well.

Also, use `.get_json()` for request parsing, which allows us to get rid of the `json` import.